### PR TITLE
DT-696: Encryption key validation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 COPY pom.xml .
 RUN mvn verify --fail-never -Dkeycloak.version=$KEYCLOAK_VERSION
 COPY src ./src
-RUN mvn package -o -Dkeycloak.version=$KEYCLOAK_VERSION
+RUN mvn package -Dkeycloak.version=$KEYCLOAK_VERSION
 
 ### Build customized Keycloak
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ FROM maven:3-openjdk-17-slim AS provider-pii
 ARG KEYCLOAK_VERSION
 WORKDIR /app
 COPY pom.xml .
-RUN mvn verify --fail-never -Dkeycloak.version=$KEYCLOAK_VERSION
+RUN mvn test verify -Dkeycloak.version=$KEYCLOAK_VERSION
 COPY src ./src
-RUN mvn package -Dkeycloak.version=$KEYCLOAK_VERSION
+RUN mvn package -o -Dmaven.test.skip -Dkeycloak.version=$KEYCLOAK_VERSION
 
 ### Build customized Keycloak
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
         <maven.compiler.target>17</maven.compiler.target>
         <keycloak.version>25.0.1</keycloak.version>
         <netbeans.hint.jdkPlatform>JDK_17</netbeans.hint.jdkPlatform>
+        <junit.jupiter.version>5.9.2</junit.jupiter.version>
     </properties>
     <dependencies>
         <dependency>
@@ -20,5 +21,29 @@
             <version>${keycloak.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>uk.org.webcompere</groupId>
+            <artifactId>system-stubs-jupiter</artifactId>
+            <version>1.2.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- Tells the JVM when running tests to open java.util for reflection by unnamed modules. Required by system-stubs-jupiter -->
+                    <argLine>--add-opens java.base/java.util=ALL-UNNAMED</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.2</version>
                 <configuration>
                     <!-- Tells the JVM when running tests to open java.util for reflection by unnamed modules. Required by system-stubs-jupiter -->
                     <argLine>--add-opens java.base/java.util=ALL-UNNAMED</argLine>

--- a/src/test/java/my/unifi/eset/keycloak/piidataencryption/utils/EncryptionUtilsTest.java
+++ b/src/test/java/my/unifi/eset/keycloak/piidataencryption/utils/EncryptionUtilsTest.java
@@ -1,0 +1,64 @@
+package my.unifi.eset.keycloak.piidataencryption.utils;
+
+import org.junit.jupiter.api.BeforeEach;
+
+import javax.crypto.SecretKey;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+
+import java.security.NoSuchAlgorithmException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(SystemStubsExtension.class)
+class EncryptionUtilsTest {
+
+    @SystemStub
+    private EnvironmentVariables environmentVariables;
+
+    protected final String envVarKey = "KC_PII_ENCKEY";
+    protected final String validEncKey = "1234567891123456";
+
+    @BeforeEach
+    void setUp() {
+        EncryptionUtils.key = null;
+
+        environmentVariables.set(envVarKey, validEncKey);
+    }
+
+    @Test
+    void testEncryptValue() throws NoSuchAlgorithmException {
+        String encryptedValue = EncryptionUtils.encryptValue("test");
+        assertNotEquals("test", encryptedValue);
+
+        String decryptedValue = EncryptionUtils.decryptValue(encryptedValue);
+        assertEquals("test", decryptedValue);
+    }
+
+    @Test
+    void testDecryptValue() throws NoSuchAlgorithmException {
+        SecretKey key = EncryptionUtils.getEncryptionKey();
+
+        String decryptedValue = EncryptionUtils.decryptValue("$$$GTaogsGC8vbgE098AN9kC+UCHD8vYzVgFF0hFDnuKIw=");
+
+        assertEquals("test", decryptedValue);
+    }
+
+    @Test
+    void testWrongKeySize() {
+        environmentVariables.set(envVarKey, "invalid");
+
+        Throwable thrown = assertThrows(RuntimeException.class, () -> {
+            EncryptionUtils.getEncryptionKey();
+        });
+
+        assertEquals("Invalid encryption key for algorithm AES/CBC/PKCS5Padding", thrown.getMessage());
+
+
+        environmentVariables.set(envVarKey, validEncKey);
+        assertDoesNotThrow(() -> EncryptionUtils.getEncryptionKey(), "should work once the key is correct and not reuse the previous one");
+    }
+}


### PR DESCRIPTION
Added a key validation check on "startup", eliminating the risk of having an invalid key
and silently failing encryption. Encryption functions ignore errors,
potentially leaving data unencrypted.